### PR TITLE
Improve the Roll Command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,33 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.spigotmc</groupId>
+      <artifactId>spigot-api</artifactId>
+      <version>1.13.1-R0.1-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.bernardomg.tabletop</groupId>
+      <artifactId>dice</artifactId>
+      <version>2.0.4</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.5.11</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <plugin>
@@ -52,7 +79,14 @@
     </resources>
   </build>
 
-  <repositories><repository><id>spigotmc-repo</id><url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url></repository><repository><id>sonatype</id><url>https://oss.sonatype.org/content/groups/public/</url></repository></repositories>
-
-  <dependencies><dependency><groupId>org.spigotmc</groupId><artifactId>spigot-api</artifactId><version>1.13.1-R0.1-SNAPSHOT</version><scope>provided</scope></dependency></dependencies>
+  <repositories>
+    <repository>
+      <id>spigotmc-repo</id>
+      <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+    </repository>
+    <repository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/groups/public/</url>
+    </repository>
+  </repositories>
 </project>

--- a/src/main/java/rpsystem/Commands/RollCommand.java
+++ b/src/main/java/rpsystem/Commands/RollCommand.java
@@ -1,0 +1,60 @@
+package rpsystem.Commands;
+
+import com.bernardomg.tabletop.dice.history.RollHistory;
+import com.bernardomg.tabletop.dice.interpreter.DiceInterpreter;
+import com.bernardomg.tabletop.dice.interpreter.DiceRoller;
+import com.bernardomg.tabletop.dice.parser.DefaultDiceParser;
+import com.bernardomg.tabletop.dice.parser.DiceParser;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import rpsystem.Main;
+
+import java.util.regex.Pattern;
+
+public class RollCommand {
+
+    Main main = null;
+
+    static final DiceParser parser = new DefaultDiceParser();
+    static final DiceInterpreter<RollHistory> roller = new DiceRoller();
+
+    static final String usageMsg = ChatColor.RED + "Usage: /roll (dice-count)d(side-count)+(modifier)";
+    static final String successMsg = ChatColor.GREEN + "You rolled a %s with a total value of %d";
+    public static final String invalidSyntaxMsg = ChatColor.RED + "Sorry! Invalid arguments, must be in standard Dice Notation (2d6+12)";
+    public static final String noPermMsg = ChatColor.RED + "Sorry! In order to use this command, you need the following permission: 'rp.roll'";
+
+    public RollCommand(Main plugin) {
+        main = plugin;
+    }
+
+    public static void rollDice(CommandSender sender, String[] args) {
+        // player check
+        if (!(sender instanceof Player)) {
+            return;
+        }
+
+        Player player = (Player) sender;
+
+        if (player.hasPermission("rp.roll") || player.hasPermission("rp.default")) {
+
+            // zero args check
+            if (args.length < 1) {
+                player.sendMessage(usageMsg);
+                return;
+            }
+
+            // Invalid syntax check
+            if (!Pattern.matches("^(\\d+)?d(\\d+)([+-]\\d+)?$", args[0])) {
+                player.sendMessage(invalidSyntaxMsg);
+                return;
+            }
+
+            final RollHistory rolls = parser.parse(args[0], roller);
+            player.sendMessage(String.format(successMsg, rolls.getRollResults(), rolls.getTotalRoll()));
+
+        } else {
+            player.sendMessage(noPermMsg);
+        }
+    }
+}

--- a/src/main/java/rpsystem/Main.java
+++ b/src/main/java/rpsystem/Main.java
@@ -53,6 +53,7 @@ public class Main extends JavaPlugin implements Listener {
         System.out.println("Medieval Roleplay Engine plugin disabled.");
     }
 
+    @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
         return commands.interpretCommand(sender, label, args);
     }

--- a/src/main/java/rpsystem/Subsystems/CommandSubsystem.java
+++ b/src/main/java/rpsystem/Subsystems/CommandSubsystem.java
@@ -5,6 +5,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import rpsystem.Commands.BirdCommand;
 import rpsystem.Commands.CardCommand;
+import rpsystem.Commands.RollCommand;
 import rpsystem.Commands.TitleCommand;
 import rpsystem.Main;
 
@@ -166,13 +167,8 @@ public class CommandSubsystem {
                 Player player = (Player) sender;
                 if (player.hasPermission("rp.roll") || player.hasPermission("rp.dice") || player.hasPermission("rp.default")) {
                     if (args.length > 0) {
-                        try {
-                            int max = Integer.parseInt(args[0]);
-                            sendMessageToPlayersWithinDistance(player,ChatColor.AQUA + "" + ChatColor.ITALIC + player.getName() + " has rolled a " + rollDice(max) + " out of " + max + ".", 25);
-                        }
-                        catch(Exception ignored) {
-
-                        }
+                        RollCommand.rollDice(sender, args);
+                        return true;
                     }
                 }
                 else {

--- a/src/main/java/rpsystem/Subsystems/UtilitySubsystem.java
+++ b/src/main/java/rpsystem/Subsystems/UtilitySubsystem.java
@@ -60,9 +60,4 @@ public class UtilitySubsystem {
             }
         }
     }
-
-    public static int rollDice(int max) {
-        return (int)(Math.random() * max + 1);
-    }
-
 }

--- a/src/test/java/rpsystem/Commands/RollCommandTest.java
+++ b/src/test/java/rpsystem/Commands/RollCommandTest.java
@@ -1,0 +1,54 @@
+package rpsystem.Commands;
+
+import org.bukkit.entity.Player;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static rpsystem.Commands.RollCommand.*;
+
+public class RollCommandTest {
+
+    @Mock
+    Player mockPlayer = mock(Player.class);
+
+    @Test
+    public void itShouldRequirePermissions() {
+        when(mockPlayer.hasPermission(anyString())).thenReturn(false);
+
+        rollDice(mockPlayer, new String[]{"1d6"});
+
+        verify(mockPlayer).sendMessage(noPermMsg);
+    }
+
+    @Test
+    public void itShouldRoll1d6() {
+        when(mockPlayer.hasPermission(anyString())).thenReturn(true);
+
+        rollDice(mockPlayer, new String[]{"1d6"});
+
+        verify(mockPlayer).sendMessage(anyString());
+        verify(mockPlayer, never()).sendMessage(noPermMsg);
+    }
+
+    @Test
+    public void itShouldRoll1d20Plus5() {
+        when(mockPlayer.hasPermission(anyString())).thenReturn(true);
+
+        rollDice(mockPlayer, new String[]{"1d20+5"});
+
+        verify(mockPlayer).sendMessage(anyString());
+        verify(mockPlayer, never()).sendMessage(noPermMsg);
+    }
+
+    @Test
+    public void itShouldRespondWithImproperSyntax() {
+        when(mockPlayer.hasPermission(anyString())).thenReturn(true);
+
+        rollDice(mockPlayer, new String[]{"1d20 + 5"});
+
+        verify(mockPlayer).sendMessage(invalidSyntaxMsg);
+    }
+
+}


### PR DESCRIPTION
Using this Dice Notation library, users should now be able to run a /roll command using the standard Dice Notation (2d6+12).  I've even added a few rudimentary JUnit Tests as a launching point to try and see what we'd need to do to get these plugins unit tested.